### PR TITLE
Fixed pokémon with hooves defs

### DIFF
--- a/Defs/Bodies/Bodies_Pokemon_Quadruped.xml
+++ b/Defs/Bodies/Bodies_Pokemon_Quadruped.xml
@@ -533,5 +533,181 @@
     </corePart>
   </BodyDef>
 
+  <BodyDef>
+    <defName>PW_QuadrupedPokemonWithHoovesAndTail</defName>
+    <label>quadruped Pokemon</label>
+    <corePart>
+      <def>Body</def>
+      <height>Middle</height>
+      <depth>Outside</depth>
+      <parts>
+        <li>
+          <def>Tail</def>
+          <coverage>0.07</coverage>
+        </li>
+        <li>
+          <def>Spine</def>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Stomach</def>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Heart</def>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Lung</def>
+          <customLabel>left lung</customLabel>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Lung</def>
+          <customLabel>right lung</customLabel>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Kidney</def>
+          <customLabel>left kidney</customLabel>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Kidney</def>
+          <customLabel>right kidney</customLabel>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Liver</def>
+          <coverage>0.03</coverage>
+          <depth>Inside</depth>
+        </li>
+        <li>
+          <def>Neck</def>
+          <coverage>0.22</coverage>
+          <height>Top</height>
+          <parts>
+            <li>
+              <def>Head</def>
+              <coverage>0.75</coverage>
+              <groups>
+                <li>HeadAttackTool</li>
+              </groups>
+              <parts>
+                <li>
+                  <def>Skull</def>
+                  <coverage>0.25</coverage>
+                  <depth>Inside</depth>
+                  <parts>
+                    <li>
+                      <def>Brain</def>
+                      <coverage>0.7</coverage>
+                      <depth>Inside</depth>
+                    </li>
+                  </parts>
+                </li>
+                <li>
+                  <def>Eye</def>
+                  <customLabel>left eye</customLabel>
+                  <coverage>0.12</coverage>
+                </li>
+                <li>
+                  <def>Eye</def>
+                  <customLabel>right eye</customLabel>
+                  <coverage>0.12</coverage>
+                </li>
+                <li>
+                  <def>Ear</def>
+                  <customLabel>left ear</customLabel>
+                  <coverage>0.08</coverage>
+                </li>
+                <li>
+                  <def>Ear</def>
+                  <customLabel>right ear</customLabel>
+                  <coverage>0.08</coverage>
+                </li>
+                <li>
+                  <def>Nose</def>
+                  <coverage>0.1</coverage>
+                </li>
+                <li>
+                  <def>AnimalJaw</def>
+                  <coverage>0.1</coverage>
+                  <groups>
+                    <li>Teeth</li>
+                  </groups>
+                </li>
+              </parts>
+            </li>
+          </parts>
+        </li>
+        <li>
+          <def>Leg</def>
+          <customLabel>front left leg</customLabel>
+          <coverage>0.07</coverage>
+          <height>Bottom</height>
+          <groups>
+            <li>FrontLeftLeg</li>
+          </groups>
+          <parts>
+            <li>
+              <def>Hoof</def>
+              <customLabel>front left hoof</customLabel>
+              <coverage>0.15</coverage>
+            </li>
+          </parts>
+        </li>
+        <li>
+          <def>Leg</def>
+          <customLabel>front right leg</customLabel>
+          <coverage>0.07</coverage>
+          <height>Bottom</height>
+          <groups>
+            <li>FrontRightLeg</li>
+          </groups>
+          <parts>
+            <li>
+              <def>Hoof</def>
+              <customLabel>front right hoof</customLabel>
+              <coverage>0.15</coverage>
+            </li>
+          </parts>
+        </li>
+        <li>
+          <def>Leg</def>
+          <customLabel>rear left leg</customLabel>
+          <coverage>0.07</coverage>
+          <height>Bottom</height>
+          <parts>
+            <li>
+              <def>Hoof</def>
+              <customLabel>rear left hoof</customLabel>
+              <coverage>0.15</coverage>
+            </li>
+          </parts>
+        </li>
+        <li>
+          <def>Leg</def>
+          <customLabel>rear right leg</customLabel>
+          <coverage>0.07</coverage>
+          <height>Bottom</height>
+          <parts>
+            <li>
+              <def>Hoof</def>
+              <customLabel>rear right hoof</customLabel>
+              <coverage>0.15</coverage>
+            </li>
+          </parts>
+        </li>
+      </parts>
+    </corePart>
+  </BodyDef>
 
 </Defs>

--- a/Defs/ThingDefs_Races/Races_Pokemon.xml
+++ b/Defs/ThingDefs_Races/Races_Pokemon.xml
@@ -12155,7 +12155,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <petness>1.0</petness>
       <packAnimal>true</packAnimal>
       <herdAnimal>false</herdAnimal>
@@ -12313,7 +12313,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <petness>1.0</petness>
       <packAnimal>true</packAnimal>
       <herdAnimal>false</herdAnimal>
@@ -20146,7 +20146,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <petness>1.0</petness>
       <packAnimal>true</packAnimal>
       <herdAnimal>false</herdAnimal>
@@ -32270,7 +32270,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <petness>1.0</petness>
       <packAnimal>true</packAnimal>
       <herdAnimal>false</herdAnimal>
@@ -37370,7 +37370,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <petness>1.0</petness>
       <packAnimal>true</packAnimal>
       <herdAnimal>false</herdAnimal>
@@ -78472,7 +78472,7 @@
       <li>PokeWorld.ITab_Pawn_Moves</li>
     </inspectorTabs>
     <race>
-      <body>PW_QuadrupedPokemonWithPaws</body>
+      <body>PW_QuadrupedPokemonWithHoovesAndTail</body>
       <hasGenders>false</hasGenders>
       <herdMigrationAllowed>false</herdMigrationAllowed>
       <petness>1.0</petness>


### PR DESCRIPTION
- Body def "PW_QuadrupedPokemonWithHooves" was not even used at all in the project (it will remain unused for now, though).
- Created "PW_QuadrupedPokemonWithHoovesAndTail" body def, and used it in the following pokémon, who were incorrectly using "PW_QuadrupedPokemonWithPaws":
  * Ponyta, Rapidash, Tauros, Girafarig, Stantler, Arceus