### PR TITLE
Fix StockGenerator_Clothes patch performance

### DIFF
--- a/Source/PokeWorld/PokeWorld/Harmony_Patching/StockGenerator_Clothes_HandlesThingDef_Patch.cs
+++ b/Source/PokeWorld/PokeWorld/Harmony_Patching/StockGenerator_Clothes_HandlesThingDef_Patch.cs
@@ -13,14 +13,20 @@ namespace PokeWorld
 	[HarmonyPatch("HandlesThingDef")]
 	public class StockGenerator_Clothes_HandlesThingDef_Patch
 	{
-		public static void Postfix(ThingDef __0, bool __result)
+		private static ISet<ThingDef> pwBelts;
+
+		public static void Prepare()
 		{
-			if(__result == true)
+			// Cache matching defs during patching to avoid prohibitive performance overhead when a trader is on the map (#23)
+			pwBelts = DefDatabase<ThingDef>.AllDefs.Where((ThingDef x) => x.thingCategories != null && x.thingCategories.Contains(DefDatabase<ThingCategoryDef>.GetNamed("PW_Belts"))).ToHashSet();
+
+		}
+
+		public static void Postfix(ThingDef __0, ref bool __result)
+		{
+			if(__result == true && pwBelts.Contains(__0))
             {
-				if (DefDatabase<ThingDef>.AllDefs.Where((ThingDef x) => x.thingCategories != null && x.thingCategories.Contains(DefDatabase<ThingCategoryDef>.GetNamed("PW_Belts"))).Contains(__0))
-				{
-					__result = false;
-				}
+				__result = false;
 			}
 		}
 	

--- a/Source/PokeWorld/PokeWorld/PokeWorld.csproj
+++ b/Source/PokeWorld/PokeWorld/PokeWorld.csproj
@@ -39,7 +39,7 @@
       <HintPath>..\..\..\Assemblies\1SettingsHelper.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>D:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -51,7 +51,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>D:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">


### PR DESCRIPTION
The current StockGenerator_Clothes_HandlesThingDef_Patch implementation
imposes a prohibitive performance overhead when a trader is active on
the map due to it iterating across the entire def database every time
in a high call frequency patch. As a fix, cache the set of defs to be
matched at the patching stage.

This patch was actually a no-op because __result was not declared as a
reference parameter, so the original return value wouldn't have been
modified, so fix that as well.

Also make the build more portable by converting some reference path to
relative ones so that they do not assume a particular install directory
for the game.

Closes #23 